### PR TITLE
feat: Add provider and model to image metadata

### DIFF
--- a/inc/class-image-handler.php
+++ b/inc/class-image-handler.php
@@ -32,9 +32,11 @@ class KaiGen_Image_Handler {
      *
      * @param string $image_data The raw image data or URL.
      * @param string $prompt The prompt used to generate the image (for alt text).
+     * @param string $provider_name The name of the image generation provider.
+     * @param string $model_id The ID of the model used for generation.
      * @return array|WP_Error Array containing the uploaded image URL and ID, or WP_Error on failure.
      */
-    public static function upload_to_media_library($image_data, $prompt) {
+    public static function upload_to_media_library($image_data, $prompt, $provider_name, $model_id) {
         // Download the image if a URL is provided
         if (filter_var($image_data, FILTER_VALIDATE_URL)) {
             $image_data = self::download_image($image_data);
@@ -69,7 +71,7 @@ class KaiGen_Image_Handler {
         $attachment = [
             'post_mime_type' => $filetype['type'],
             'post_title'     => $title,
-            'post_content'   => 'Generated with prompt: ' . $prompt,
+            'post_content'   => 'Generated with prompt: ' . $prompt . '. Provider: ' . $provider_name . ', Model: ' . $model_id,
             'post_status'    => 'inherit',
             'post_excerpt'   => wp_trim_words($prompt, 5, '...'),
         ];

--- a/inc/class-image-provider.php
+++ b/inc/class-image-provider.php
@@ -136,13 +136,13 @@ abstract class KaiGen_Image_Provider implements KaiGen_Image_Provider_Interface 
                 return $result;
             } else if (is_array($result) && isset($result['url'])) {
                 // This has a URL but no valid ID, so upload to media library
-                return KaiGen_Image_Handler::upload_to_media_library($result['url'], $prompt);
+                return KaiGen_Image_Handler::upload_to_media_library($result['url'], $prompt, $this->get_name(), $this->get_current_model());
             } else if (is_string($result) && filter_var($result, FILTER_VALIDATE_URL)) {
                 // This is a URL string, upload to media library
-                return KaiGen_Image_Handler::upload_to_media_library($result, $prompt);
+                return KaiGen_Image_Handler::upload_to_media_library($result, $prompt, $this->get_name(), $this->get_current_model());
             } else if (is_string($result) && strlen($result) > 100) {
                 // This is likely raw image data, upload to media library
-                return KaiGen_Image_Handler::upload_to_media_library($result, $prompt);
+                return KaiGen_Image_Handler::upload_to_media_library($result, $prompt, $this->get_name(), $this->get_current_model());
             }
             
             // Fallback for unexpected result format


### PR DESCRIPTION
This change updates the image uploading process to include the AI provider's name and the specific model used for generation within the image's metadata.

- Modifies `inc/class-image-handler.php`:
    - The `upload_to_media_library` function now accepts provider name and model ID as parameters.
    - The image's "Description" field (post_content) is updated to include "Provider: [Provider Name], Model: [Model ID]".

- Modifies `inc/class-image-provider.php`:
    - The `generate_image` function now passes the provider's name (from `get_name()`) and model ID (from `get_current_model()`) to `upload_to_media_library`.

This enhances the traceability of generated images by storing the generation source directly in the WordPress media library.