### PR TITLE
Add reference image selection

### DIFF
--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -58,8 +58,9 @@ class KaiGen_Admin {
 	private function init_hooks() {
 		add_action('admin_menu', [$this, 'add_settings_page']);
 		add_action('admin_init', [$this, 'register_settings']);
-		add_action('admin_enqueue_scripts', [$this, 'enqueue_scripts']);
-		
+	add_action('admin_enqueue_scripts', [$this, 'enqueue_scripts']);
+	add_action('init', [$this, 'register_reference_image_meta']);
+			
 		// Add settings link to plugin page
 		add_filter('plugin_action_links_' . plugin_basename(KAIGEN_PLUGIN_FILE), [$this, 'add_plugin_action_links']);
 
@@ -456,11 +457,64 @@ class KaiGen_Admin {
 	 */
 	private function provider_supports_image_to_image($provider) {
 		if (empty($provider)) {
-			return false;
+		return false;
 		}
 		
 		$provider_manager = kaigen_provider_manager();
 		return $provider_manager->provider_supports_image_to_image($provider);
+}
+
+/**
+ * Registers the reference image meta and edit form fields.
+ *
+ * @return void
+ */
+	public function register_reference_image_meta() {
+		register_post_meta(
+		'attachment',
+		'kaigen_reference_image',
+		[
+		'show_in_rest' => true,
+		'single'       => true,
+		'type'         => 'boolean',
+		'auth_callback' => function() {
+		return current_user_can('upload_files');
+		},
+		]
+		);
+		
+		add_filter('attachment_fields_to_edit', [\$this, 'add_reference_field'], 10, 2);
+		add_filter('attachment_fields_to_save', [\$this, 'save_reference_field'], 10, 2);
+	}
+
+/**
+ * Adds the reference image checkbox to the attachment edit form.
+ *
+ * @param array   \$form_fields Current form fields.
+ * @param WP_Post \$post        Attachment post.
+ * @return array Modified form fields.
+ */
+	public function add_reference_field(\$form_fields, \$post) {
+		\$value = (bool) get_post_meta(\$post->ID, 'kaigen_reference_image', true);
+		\$form_fields['kaigen_reference_image'] = [
+		'label' => __('Reference Image', 'kaigen'),
+		'input' => 'html',
+		'html'  => '<input type="checkbox" name="attachments[' . esc_attr(\$post->ID) . '][kaigen_reference_image]" value="1"' . checked(\$value, true, false) . '/>',
+		];
+		return \$form_fields;
+}
+
+/**
+ * Saves the reference image checkbox value.
+ *
+ * @param array \$post       Attachment post data.
+ * @param array \$attachment Attachment form fields.
+ * @return array Modified post data.
+ */
+	public function save_reference_field(\$post, \$attachment) {
+		\$value = isset(\$attachment['kaigen_reference_image']) ? 1 : 0;
+		update_post_meta(\$post['ID'], 'kaigen_reference_image', \$value);
+		return \$post;
 	}
 }
 

--- a/inc/class-rest-api.php
+++ b/inc/class-rest-api.php
@@ -75,6 +75,13 @@ final class KaiGen_REST_Controller {
             'callback'            => [$this, 'get_image_to_image_providers'],
             'permission_callback' => [$this, 'check_permission'],
         ]);
+
+        // Register the reference images endpoint
+        register_rest_route(self::API_NAMESPACE, '/reference-images', [
+            'methods'             => 'GET',
+            'callback'            => [$this, 'get_reference_images'],
+            'permission_callback' => [$this, 'check_permission'],
+        ]);
     }
 
     /**
@@ -379,6 +386,32 @@ final class KaiGen_REST_Controller {
                 500
             );
         }
+    }
+
+    /**
+     * Retrieves all images marked as reference images.
+     *
+     * @return WP_REST_Response The response containing reference images.
+     */
+    public function get_reference_images() {
+        $query = new WP_Query([
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'posts_per_page' => -1,
+            'meta_key'       => 'kaigen_reference_image',
+            'meta_value'     => 1,
+        ]);
+
+        $images = [];
+        foreach ($query->posts as $post) {
+            $images[] = [
+                'id'  => $post->ID,
+                'url' => wp_get_attachment_url($post->ID),
+                'alt' => get_post_meta($post->ID, '_wp_attachment_image_alt', true),
+            ];
+        }
+
+        return new WP_REST_Response($images, 200);
     }
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -107,4 +107,22 @@ export const generateImage = async (prompt, callback, options = {}) => {
             error: error.message || 'An unknown error occurred while generating the image'
         });
     }
-}; 
+};
+
+/**
+ * Fetches all reference images marked in the media library.
+ *
+ * @returns {Promise<Array>} Array of image objects.
+ */
+export const fetchReferenceImages = async () => {
+    try {
+        const response = await wp.apiFetch({
+            path: '/kaigen/v1/reference-images',
+            method: 'GET',
+        });
+        return Array.isArray(response) ? response : [];
+    } catch (error) {
+        console.error('Failed to fetch reference images:', error);
+        return [];
+    }
+};

--- a/src/components/AITab.js
+++ b/src/components/AITab.js
@@ -1,8 +1,8 @@
 // This file contains the AITab React component used to generate AI images through a modal.
 
-import { useState } from '@wordpress/element'; // Import WordPress hooks.
+import { useState, useEffect } from '@wordpress/element'; // Import WordPress hooks.
 import { Button, TextareaControl, Modal, Spinner } from '@wordpress/components'; // Import necessary UI components.
-import { generateImage } from '../api'; // Import API functions.
+import { generateImage, fetchReferenceImages } from '../api'; // Import API functions.
 
 /**
  * AITab component for generating AI images.
@@ -18,6 +18,16 @@ const AITab = ({ onSelect, shouldDisplay }) => { // This is the AITab functional
     const [prompt, setPrompt] = useState(''); // Stores the image prompt.
     const [isLoading, setIsLoading] = useState(false); // Indicates if image generation is in progress.
     const [error, setError] = useState(null); // Holds any error messages.
+    const [referenceImages, setReferenceImages] = useState([]);
+    const [selectedRef, setSelectedRef] = useState(null);
+
+    const supportsImageToImage = window.kaiGen?.supportsImageToImage || false;
+
+    useEffect(() => {
+        if (isModalOpen && supportsImageToImage) {
+            fetchReferenceImages().then(setReferenceImages);
+        }
+    }, [isModalOpen]);
 
     /**
      * Handles the image generation process when the Generate button is clicked.
@@ -33,6 +43,11 @@ const AITab = ({ onSelect, shouldDisplay }) => { // This is the AITab functional
         setIsLoading(true); // Start loading state.
         setError(null); // Clear any previous errors.
 
+        const options = {};
+        if (selectedRef) {
+            options.sourceImageUrl = selectedRef.url;
+        }
+
         // Call generateImage API function with the prompt
         generateImage(prompt.trim(), (media) => {
             if (media.error) {
@@ -43,7 +58,7 @@ const AITab = ({ onSelect, shouldDisplay }) => { // This is the AITab functional
                 setIsLoading(false); // End loading state.
                 setIsModalOpen(false); // Close the modal.
             }
-        });
+        }, options);
     };
 
     // Do not render the component if shouldDisplay is false.
@@ -80,6 +95,29 @@ const AITab = ({ onSelect, shouldDisplay }) => { // This is the AITab functional
                         onChange={setPrompt} // Updates the prompt state.
                         rows={4}
                     />
+
+                    {supportsImageToImage && referenceImages.length > 0 && (
+                        <>
+                            <p>Reference Images</p>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginBottom: '8px' }}>
+                                {referenceImages.map((img) => (
+                                    <img
+                                        key={img.id}
+                                        src={img.url}
+                                        alt={img.alt || ''}
+                                        onClick={() => setSelectedRef(img)}
+                                        style={{
+                                            width: '80px',
+                                            height: '80px',
+                                            objectFit: 'cover',
+                                            cursor: 'pointer',
+                                            border: selectedRef && selectedRef.id === img.id ? '2px solid #007cba' : '2px solid transparent',
+                                        }}
+                                    />
+                                ))}
+                            </div>
+                        </>
+                    )}
                     
                     {/* Button to trigger image generation. */}
                     <Button


### PR DESCRIPTION
## Summary
- add endpoint to fetch reference images via REST API
- allow marking attachments as reference images via admin
- fetch and select reference images in AITab modal
- expose helper in API layer

## Testing
- `npm run build` *(fails: wp-scripts not found)*
- `npm run lint:js` *(fails: wp-scripts not found)*
- `npm run lint:css` *(fails: wp-scripts not found)*
- `npm run format` *(fails: wp-scripts not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da70701b4832ea7b94e1518fce842